### PR TITLE
Exit and return an exit status if any `exec` subcommand fails.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,9 +1,6 @@
 Style/Documentation:
   Enabled: false
 
-Style/TrailingCommaInLiteral:
-  EnforcedStyleForMultiline: consistent_comma
-
 Metrics/BlockLength:
   Enabled: false
 
@@ -21,3 +18,9 @@ Metrics/CyclomaticComplexity:
 
 AllCops:
   TargetRubyVersion: 2.2
+
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: consistent_comma
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: consistent_comma

--- a/lib/commands/exec.rb
+++ b/lib/commands/exec.rb
@@ -1,4 +1,6 @@
 class MonorepoCLI
+  EXIT_STATUS_ZERO = 0
+
   desc 'exec [COMMAND]', 'exec commands at all the monorepo repo'
   method_option :config_filename, aliases: '-c'
   method_option :bundler, aliases: '-b'
@@ -32,6 +34,8 @@ class MonorepoCLI
     subdirs.each do |gem|
       puts "executing `#{local_command_str}` at #{gem}..."
       system "cd #{gem} && pwd && #{local_command_str}"
+      status = $CHILD_STATUS
+      exit status.exitstatus unless status.exitstatus == EXIT_STATUS_ZERO
     end
   end
 end

--- a/lib/monorepo.rb
+++ b/lib/monorepo.rb
@@ -1,3 +1,4 @@
+require 'english'
 require 'thor'
 require_relative './version'
 

--- a/lib/monorepo.rb
+++ b/lib/monorepo.rb
@@ -1,4 +1,4 @@
-require 'english'
+require 'English'
 require 'thor'
 require_relative './version'
 

--- a/monorepo.gemspec
+++ b/monorepo.gemspec
@@ -1,5 +1,4 @@
-
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require './lib/version'
 

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -63,4 +63,21 @@ describe 'Command `exec`' do
     MonorepoCLI.start(['exec', 'ls', '-c', 'my_monorepo_config'])
     # TODO: I want to capture STDOUT
   end
+
+  it 'exits with a non-zero exit status if command fails for any gem' do
+    config = {
+      'monorepo' => '0.0.0',
+      'gems' => 'gems/*',
+      'bundler' => 'no',
+    }
+
+    File.open('./monorepofile', 'w') { |f| f.write(config.to_yaml) }
+    %w[./gems ./gems/gem0 ./gems/gem1].each do |dir|
+      Dir.mkdir dir
+    end
+
+    system 'monorepo exec 1/0'
+    status = $CHILD_STATUS
+    expect(status.exitstatus).to_not be_zero
+  end
 end


### PR DESCRIPTION
This commit relates to this issue:

https://github.com/kamataryo/monorepo/issues/24#issuecomment-426838432

It should make failures more obvious.

This commit also updates `.rubocop.yml` as Rubocop updates caused the
deprecation error:
"
Error: The `Style/TrailingCommaInLiteral` cop no longer exists. Please use
`Style/TrailingCommaInArrayLiteral` and/or
`Style/TrailingCommaInHashLiteral` instead. (obsolete configuration found in
.rubocop.yml, please update it)
"

Rubocop also asked to use `$CHILD_STATUS` instead of `$?` which means
`require`ing `english` from stdlib. (Sorry, it's a bit obnoxious to
non-English speakers to have a gem called english required.)

If there's too much going on here for one commit, I'm happy to spit it.